### PR TITLE
Fix build instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,5 +76,5 @@ go get -d ./...
 ./build_android.sh intra
 
 # other unsupported, unmaintained builds:
-./build_[ios|android|macos|windows].sh
+./build_[ios|linux|macos|windows].sh
 ```


### PR DESCRIPTION
According to the docs above. Android is the supported flavor.

iOS, Linux, macOS & Windows are the unsupported, unmaintained builds.

This might just be a typo to be fixed ;)