### PR TITLE
intra/tcp.go: don't create TCP endpoint before Dial() returns

### DIFF
--- a/intra/tcp.go
+++ b/intra/tcp.go
@@ -186,14 +186,6 @@ func (h *tcpHandler) Proxy(gconn *netstack.GTCPConn, src, target netip.AddrPort)
 		return deny
 	}
 
-	// handshake; since we assume a duplex-stream from here on
-	if open, err = gconn.Establish(); !open {
-		log.E("tcp: %s connect err %v; %s => %s for %s", cid, err, src, target, uid)
-		clos(gconn)
-		h.queueSummary(smm.done(err))
-		return deny // == !open
-	}
-
 	if isAnyBasePid(pids) { // see udp.go:Connect
 		if h.dnsOverride(gconn, target, uid) {
 			// SocketSummary not sent; x.DNSSummary supercedes it
@@ -267,6 +259,11 @@ func (h *tcpHandler) handle(px ipn.Proxy, src net.Conn, boundSrc, target netip.A
 		clos(pc)
 		log.W("tcp: err dialing %s proxy(%s) to dst(%v) for %s: %v",
 			smm.ID, px.ID(), target, smm.UID, err)
+		return err
+	}
+
+	gconn := src.(*netstack.GTCPConn)
+	if open, err := gconn.Establish(); !open {
 		return err
 	}
 

--- a/intra/tcp.go
+++ b/intra/tcp.go
@@ -187,8 +187,17 @@ func (h *tcpHandler) Proxy(gconn *netstack.GTCPConn, src, target netip.AddrPort)
 	}
 
 	if isAnyBasePid(pids) { // see udp.go:Connect
-		if h.dnsOverride(gconn, target, uid) {
+		if target.IsValid() && h.resolver.IsDnsAddr(target) {
 			// SocketSummary not sent; x.DNSSummary supercedes it
+			if _, err := gconn.Establish(); err != nil {
+				clos(gconn)
+				h.queueSummary(smm.done(err))
+				return deny // == !open
+			}
+			// conn closed by the resolver
+			core.Gx(h.proto+".dns", func() {
+				h.resolver.Serve(h.proto, gconn, uid)
+			})
 			return allow
 		} // else not a dns request
 	} // if ipn.Exit then let it connect as-is (aka exit)
@@ -263,7 +272,8 @@ func (h *tcpHandler) handle(px ipn.Proxy, src net.Conn, boundSrc, target netip.A
 	}
 
 	gconn := src.(*netstack.GTCPConn)
-	if open, err := gconn.Establish(); !open {
+	if _, err := gconn.Establish(); err != nil {
+		clos(pc)
 		return err
 	}
 


### PR DESCRIPTION
@ignoramous 
I wonder if this change breaks anything.