### PR TITLE
icmp: fix reply4()

### DIFF
--- a/intra/netstack/icmp.go
+++ b/intra/netstack/icmp.go
@@ -117,41 +117,29 @@ func (f *icmpForwarder) reply4(id stack.TransportEndpointID, pkt *stack.PacketBu
 		if !f.h.Ping(data, src, dst) { // unreachable
 			err = f.icmpErr4(pkt, header.ICMPv4DstUnreachable, header.ICMPv4HostUnreachable)
 		} else { // reachable
-			newOptions := f.ipOpts(pkt, ipHdr)
+			originRef := replyData.AsSlice()
+			replyBuf := buffer.NewViewSize(len(originRef))
+			replyRef := replyBuf.AsSlice()
 
-			// Correct IP header length (IHL in 32-bit words).
-			replyHeaderLength := uint8(header.IPv4MinimumSize + len(newOptions))
-			replyIPHdrView := buffer.NewView(int(replyHeaderLength))
-			replyIPHdrView.Write(ipHdr[:header.IPv4MinimumSize])
-			replyIPHdrView.Write(newOptions)
-
-			replyIPHdr := header.IPv4(replyIPHdrView.AsSlice())
-			replyIPHdr.SetHeaderLength(replyHeaderLength >> 2) // IHL in 32-bit words.
-			replyIPHdr.SetSourceAddress(route.LocalAddress())
-			replyIPHdr.SetDestinationAddress(route.RemoteAddress())
-			replyIPHdr.SetTTL(route.DefaultTTL())
-			replyIPHdr.SetTotalLength(uint16(len(replyIPHdr) + len(replyData.AsSlice())))
-			replyIPHdr.SetChecksum(0)
-			replyIPHdr.SetChecksum(^replyIPHdr.CalculateChecksum())
-
-			replyICMPHdr := header.ICMPv4(replyData.AsSlice())
+			copy(replyRef[4:], originRef[4:])
+			replyICMPHdr := header.ICMPv4(replyRef)
 			replyICMPHdr.SetType(header.ICMPv4EchoReply)
 			replyICMPHdr.SetCode(0) // EchoReply must have Code=0.
-			replyICMPHdr.SetChecksum(0)
-			replyICMPHdr.SetChecksum(^checksum.Checksum(replyData.AsSlice(), 0))
+			replyICMPHdr.SetChecksum(^checksum.Checksum(replyRef, 0))
 
-			replyBuf := buffer.MakeWithView(replyIPHdrView)
-			replyBuf.Append(replyData.Clone())
 			replyPkt := stack.NewPacketBuffer(stack.PacketBufferOptions{
 				ReserveHeaderBytes: int(route.MaxHeaderLength()),
-				Payload:            replyBuf,
+				Payload:            buffer.MakeWithView(replyBuf),
 			})
 
 			log.D("icmp: v4: %s: ok type %v/%v sz[%d] from %v <= %v",
 				f.o, replyICMPHdr.Type(), replyICMPHdr.Code(), len(replyICMPHdr), src, dst)
 
 			// github.com/google/gvisor/blob/738e1d995f/pkg/tcpip/network/ipv4/icmp.go#L794
-			err = route.WriteHeaderIncludedPacket(replyPkt)
+			err = route.WritePacket(stack.NetworkHeaderParams{
+				Protocol: header.ICMPv4ProtocolNumber,
+				TTL:      route.DefaultTTL(),
+			}, replyPkt)
 		}
 		loge(err)("icmp: v4: %s: wrote reply to tun; err? %v", f.o, err)
 	})


### PR DESCRIPTION
```
haha debug replyBuf: [65 0 0 84 237 199 64 0 128 1 190 171 9 9 9 9 10 0 2 100 0 0 239 131 12 60 0 0 74 174 185 145 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]
E async.go:21>icmp.go:158: icmp: v4: 9: wrote reply to tun; err? header is malformed
```
Firestack misused `IPv4.SetHeaderLength()`, `replyHeaderLength >> 2` is unnecessary.
https://github.com/celzero/firestack/blob/271e3d33b83ace94c6d8d97827bbae2fbaeb8b80/intra/netstack/icmp.go#L129
https://github.com/google/gvisor/blob/738e1d995f64d20fd11ab59a88d12b524acb672e/pkg/tcpip/header/ipv4.go#L298

The upstream has merged Amaindex's pull request https://github.com/google/gvisor/pull/11609 , so my small changes should work.